### PR TITLE
RealmeParts: Remove disabling of edge limit control interface

### DIFF
--- a/src/com/realmeparts/DeviceSettings.java
+++ b/src/com/realmeparts/DeviceSettings.java
@@ -58,7 +58,6 @@ public class DeviceSettings extends PreferenceFragment
     public static final String CABC_SYSTEM_PROPERTY = "persist.cabc_profile";
     public static final String KEY_FPS_INFO = "fps_info";
     public static final String KEY_SETTINGS_PREFIX = "device_setting_";
-    public static final String TP_LIMIT_ENABLE = "/proc/touchpanel/oppo_tp_limit_enable";
     public static final String TP_DIRECTION = "/proc/touchpanel/oppo_tp_direction";
     private static final String ProductName = Utils.ProductName();
     private static final String KEY_CATEGORY_CHARGING = "charging";

--- a/src/com/realmeparts/services/GameModeTileService.java
+++ b/src/com/realmeparts/services/GameModeTileService.java
@@ -72,7 +72,6 @@ public class GameModeTileService extends TileService {
             AppNotification.Send(this, GameModeSwitch.GameMode_Notification_Channel_ID, this.getString(R.string.game_mode_title), this.getString(R.string.game_mode_notif_content));
         } else AppNotification.Cancel(this, GameModeSwitch.GameMode_Notification_Channel_ID);
         Utils.writeValue(GameModeSwitch.getFile(), enabled ? "0" : "1");
-        Utils.writeValue(DeviceSettings.TP_LIMIT_ENABLE, enabled ? "1" : "0");
         Utils.writeValue(DeviceSettings.TP_DIRECTION, enabled ? "0" : "1");
         SystemProperties.set("perf_profile", enabled ? "0" : "1");
         if (sharedPrefs.getBoolean("dnd", false)) GameModeTileDND();

--- a/src/com/realmeparts/switch/GameModeSwitch.java
+++ b/src/com/realmeparts/switch/GameModeSwitch.java
@@ -97,7 +97,6 @@ public class GameModeSwitch implements OnPreferenceChangeListener {
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         Boolean enabled = (Boolean) newValue;
         Utils.writeValue(getFile(), enabled ? "1" : "0");
-        Utils.writeValue(DeviceSettings.TP_LIMIT_ENABLE, enabled ? "0" : "1");
         Utils.writeValue(DeviceSettings.TP_DIRECTION, enabled ? "1" : "0");
         SystemProperties.set("perf_profile", enabled ? "1" : "0");
         GameModeDND();


### PR DESCRIPTION
* Touch at the edges of the screen is not just required for gaming, hence it is better to move this change into device tree

Signed-off-by: Maanush Putcha <p.maanush@gmail.com>